### PR TITLE
Change the name Cldr.Html to Cldr.HTML

### DIFF
--- a/lib/cldr_html.ex
+++ b/lib/cldr_html.ex
@@ -1,4 +1,4 @@
-defmodule Cldr.Html do
+defmodule Cldr.HTML do
   if Code.ensure_compiled?(Cldr.Currency) do
     @type currency_select_options :: [{:currencies, list(atom() | binary())} | {:mapper, function()} | {:locale, String.t() | Cldr.LanguageTag.t()}]
 

--- a/test/cldr_html_test.exs
+++ b/test/cldr_html_test.exs
@@ -1,6 +1,6 @@
-defmodule Cldr.Html.Test do
+defmodule Cldr.HTML.Test do
   use ExUnit.Case
-  doctest Cldr.Html
+  doctest Cldr.HTML
 
 
 end


### PR DESCRIPTION
Change the name `Cldr.Html` to `Cldr.HTML`, this aligns with `Phoenix.HTML`.